### PR TITLE
Stabilize ratelimit action

### DIFF
--- a/leakfinder/src/http/mod.rs
+++ b/leakfinder/src/http/mod.rs
@@ -323,7 +323,11 @@ impl<'a> HttpParser<'a> {
             time_response_start: self.time_response_start,
             request_headers: self.request_headers,
             response_headers: self.response_headers,
-            policy_path: self.path_policy.as_ref().unwrap().policy_path.clone(),
+            policy_path: self
+                .path_policy
+                .as_ref()
+                .map(|x| x.policy_path.to_string())
+                .unwrap_or_default(),
             token: self.token.unwrap_or_default(),
             ip: self.ip.unwrap_or_default(),
             response,

--- a/leaksignal/src/http_response.rs
+++ b/leaksignal/src/http_response.rs
@@ -357,6 +357,15 @@ impl HttpContext for HttpResponseContext {
             return Action::Continue;
         }
 
+        for (name, value) in self.get_http_request_headers_bytes() {
+            let value = match String::from_utf8(value) {
+                Ok(x) => x,
+                Err(e) => String::from_utf8_lossy(&e.into_bytes()[..]).into_owned(),
+            };
+            self.parser()
+                .with_request_headers([FullHeader { name, value }]);
+        }
+
         if !self.request_started {
             self.request_started = true;
 
@@ -387,15 +396,6 @@ impl HttpContext for HttpResponseContext {
                 return Action::Continue;
             }
             self.parser().with_ip(ip);
-        }
-
-        for (name, value) in self.get_http_request_headers_bytes() {
-            let value = match String::from_utf8(value) {
-                Ok(x) => x,
-                Err(e) => String::from_utf8_lossy(&e.into_bytes()[..]).into_owned(),
-            };
-            self.parser()
-                .with_request_headers([FullHeader { name, value }]);
         }
 
         if let Some(local_service) =


### PR DESCRIPTION
* Always adds some base headers to ratelimited requests
* Prevent panic if no :path header