### PR TITLE
v0.2.1

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -138,7 +138,7 @@ Docker commands to run an Envoy proxy with LeakSignal installed.
 ```bash
 FROM envoyproxy/envoy-dev:0b1c5aca39b8c2320501ce4b94fe34f2ad5808aa
 RUN curl -O https://raw.githubusercontent.com/leaksignal/leaksignal/master/examples/envoy/envoy_local.yaml > /etc/envoy.yaml
-RUN curl -O https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm > /lib/leaksignal.wasm
+RUN curl -O https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
 RUN chmod go+r /etc/envoy.yaml
 CMD ["/usr/local/bin/envoy", "-c", "/etc/envoy.yaml"]
 ```

--- a/examples/envoy/envoy_agent.yaml
+++ b/examples/envoy/envoy_agent.yaml
@@ -50,10 +50,10 @@ static_resources:
                   code:
                     remote:
                       http_uri:
-                        uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                        uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                         timeout: 10s
                         cluster: leaksignal_infra
-                      sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                      sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                       retry_policy:
                         num_retries: 10
           - name: envoy.filters.http.router

--- a/examples/envoy/envoy_command_remote_wasm.yaml
+++ b/examples/envoy/envoy_command_remote_wasm.yaml
@@ -54,11 +54,11 @@ static_resources:
                   code:
                     remote:
                       http_uri:
-                        uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                        uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                         timeout:
                           seconds: 10
                         cluster: leaksignal_infra
-                      sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                      sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                       retry_policy:
                         num_retries: 10
           - name: envoy.filters.http.router

--- a/examples/istio/leaksignal.yaml
+++ b/examples/istio/leaksignal.yaml
@@ -39,10 +39,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                  sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_agent.yaml
+++ b/examples/istio/leaksignal_agent.yaml
@@ -39,10 +39,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                    uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                  sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_ns.yaml
+++ b/examples/istio/leaksignal_ns.yaml
@@ -38,10 +38,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                  sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_service.yaml
+++ b/examples/istio/leaksignal_service.yaml
@@ -25,10 +25,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                  sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER
@@ -89,10 +89,10 @@ spec:
                 code:
                   remote:
                     http_uri:
-                      uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_01_14_35_22_fc00c72_0.2.0/leaksignal.wasm
+                      uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
                       timeout: 10s
                       cluster: leaksignal_infra
-                    sha256: 8e4de1d8e38abf033495512b3f85e54523fb1bdf9e3bc63a63383325458be6c6
+                    sha256: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
                     retry_policy:
                       num_retries: 10
 ---


### PR DESCRIPTION
Release notes:

Changes:
* Bug fix for envoy not setting `:authority` header

Direct S3 Download: https://leakproxy.s3.us-west-2.amazonaws.com/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
Ingestion-S3 Proxy Download (used within Envoy configurations): https://ingestion.app.leaksignal.com/s3/leakproxy/2023_06_06_22_21_26_ee90359_0.2.1/leaksignal.wasm
SHA256 of leaksignal.wasm: 7f7c10615beccf923507c74883e89b49f7feabe0d4f4cce7c92cc395b789aa3f
