### PR TITLE
v0.12.1

### DIFF
--- a/docs/docs/Deployment/Istio & OSSM.md
+++ b/docs/docs/Deployment/Istio & OSSM.md
@@ -11,7 +11,7 @@ LeakSignal Operator is available on [OperatorHub](https://operatorhub.io/operato
 You can also install the operator via a Helm Chart:
 ```bash
 $ helm upgrade --install leaksignal-operator oci://registry-1.docker.io/leaksignal/leaksignal-operator \
-  --version 0.12.0-helm \
+  --version 0.12.1-helm \
   --namespace leaksignal-operator \
   --create-namespace
 ```
@@ -52,15 +52,15 @@ metadata:
   name: leaksignal-istio
 spec:
   # Version information is available at https://github.com/leaksignal/leaksignal/releases
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   # from Command, or the Deployment name in LeakAgent
   apiKey: MY_API_KEY
 ```
 
-### Single Namespace (Native)
+### Single Namespace (WASM)
 
-If you want to deploy with **Native** mode, there will be a different `proxyHash` and a `native: true` flag:
+If you want to deploy with **Native** mode, there will be a different `proxyHash` and a `native: false` flag:
 ```yaml
 apiVersion: leaksignal.com/v1
 kind: LeaksignalIstio
@@ -68,9 +68,9 @@ metadata:
   name: leaksignal-istio
 spec:
   # Version information is available at https://github.com/leaksignal/leaksignal/releases
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: e39c76c48fe7416372bc28775024dc688daf761161880a232f76d2a891b76ff5
-  native: true
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
+  native: false
   # from Command, or the Deployment name in LeakAgent
   apiKey: MY_API_KEY
 ```
@@ -86,8 +86,8 @@ metadata:
   name: leaksignal-istio
 spec:
   # Version information is available at https://github.com/leaksignal/leaksignal/releases
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   # from Command, or the Deployment name in LeakAgent
   apiKey: MY_API_KEY
 ```

--- a/docs/docs/Deployment/Lambda.md
+++ b/docs/docs/Deployment/Lambda.md
@@ -35,7 +35,7 @@ If your function is in one of the supported regions, installing LeakLambda is as
 
 ### Creating your own custom layer
 
-If you are outside the supported regions then you can create your own layer using our LeakLambda zip file hosted on S3. Simply [download the zip file](https://leakproxy.s3.us-west-2.amazonaws.com/leaklambda-0.12.0.zip), go to `Lambda` > `Layers`, click `Create Layer`, and upload the zip file. From there all you have to do is add the layer to your function.
+If you are outside the supported regions then you can create your own layer using our LeakLambda zip file hosted on S3. Simply [download the zip file](https://leakproxy.s3.us-west-2.amazonaws.com/leaklambda-0.12.1.zip), go to `Lambda` > `Layers`, click `Create Layer`, and upload the zip file. From there all you have to do is add the layer to your function.
 
 ## Setup
 

--- a/docs/docs/Deployment/NGINX Ingress.md
+++ b/docs/docs/Deployment/NGINX Ingress.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 LeakSignal publishes alternative container images for [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx) at [leaksignal/ingress-nginx](https://hub.docker.com/r/leaksignal/ingress-nginx)
 
-Tags are of the form: `$INGRESS_VERSION-$LEAKSIGNAL_VERSION`, i.e. `v1.8.1-0.12.0`. Supported versions are 1.6.4 through 1.8.1.
+Tags are of the form: `$INGRESS_VERSION-$LEAKSIGNAL_VERSION`, i.e. `v1.8.1-0.12.1`. Supported versions are 1.6.4 through 1.8.1.
 
 Example helm configuration:
 ```yaml
@@ -12,7 +12,7 @@ controller:
   image:
     registry: docker.io
     image: leaksignal/ingress-nginx
-    tag: "v1.8.1-0.12.0"
+    tag: "v1.8.1-0.12.1"
     digest: null
   config:
     main-snippet:

--- a/docs/docs/Deployment/NGINX.md
+++ b/docs/docs/Deployment/NGINX.md
@@ -8,7 +8,7 @@ LeakNGX is a native NGINX plugin to integrate LeakSignal.
 
 All module files are available via `https://leakproxy.s3.us-west-2.amazonaws.com/leakngx-$LEAKSIGNAL_VERSION-$NGINX_VERSION/libleakngx.so`
 
-Where `$LEAKSIGNAL_VERSION` is the version of LeakSignal (i.e. 0.12.0), and `$NGINX_VERSION` is a version between NGINX 1.21.6 and 1.25.2.
+Where `$LEAKSIGNAL_VERSION` is the version of LeakSignal (i.e. 0.12.1), and `$NGINX_VERSION` is a version between NGINX 1.21.6 and 1.25.2.
 Note that a special version is available for NGINX 1.21.6 supporting MUSL (for alpine linux used in ingress-nginx), with a version of `$LEAKSIGNAL-VERSION-1.21.6-musl`.
 
 ## Configuring NGINX
@@ -29,7 +29,7 @@ leakngx $API_KEY https://ingestion.app.leaksignal.com;
 
 LeakSignal publishes alternative container images for [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx) at [leaksignal/ingress-nginx](https://hub.docker.com/r/leaksignal/ingress-nginx)
 
-Tags are of the form: `$INGRESS_VERSION-$LEAKSIGNAL_VERSION`, i.e. `v1.8.1-0.12.0`. Supported versions are 1.6.4 through 1.8.1.
+Tags are of the form: `$INGRESS_VERSION-$LEAKSIGNAL_VERSION`, i.e. `v1.8.1-0.12.1`. Supported versions are 1.6.4 through 1.8.1.
 
 Example helm configuration:
 ```yaml
@@ -37,7 +37,7 @@ controller:
   image:
     registry: docker.io
     image: leaksignal/ingress-nginx
-    tag: "v1.8.1-0.12.0"
+    tag: "v1.8.1-0.12.1"
     digest: null
   config:
     main-snippet:

--- a/docs/docs/LeakAgent/Deployment/Helm Chart.md
+++ b/docs/docs/LeakAgent/Deployment/Helm Chart.md
@@ -13,7 +13,7 @@ See [Examples](https://github.com/leaksignal/leaksignal/tree/master/examples/lea
 ### Helm Install Command
 ```
 helm upgrade --install leakagent oci://registry-1.docker.io/leaksignal/leakagent \
-  --version 0.12.0-helm \
+  --version 0.12.1-helm \
   --namespace leakagent --create-namespace
 
 # or more generally
@@ -25,7 +25,7 @@ helm upgrade --install leakagent oci://registry-1.docker.io/leaksignal/leakagent
 # with a specific values.yaml (i.e. to set policies)
 
 helm upgrade --install leakagent oci://registry-1.docker.io/leaksignal/leakagent \
-  --version 0.12.0-helm \
+  --version 0.12.1-helm \
   -f ./values.yaml \
   --namespace leakagent --create-namespace
 ```

--- a/docs/docs/Operator/CRDs/ClusterLeaksignalIstio & LeaksignalIstio.md
+++ b/docs/docs/Operator/CRDs/ClusterLeaksignalIstio & LeaksignalIstio.md
@@ -4,10 +4,10 @@ The following fields are defined for the `spec` of the (Cluster)LeaksignalIstio 
 ```yaml
 
 # Required. Version string for LeakSignal Proxy deployment. Can see all versions at https://github.com/leaksignal/leaksignal/releases
-proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
+proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
 
 # Required. Hash of the downloaded bundle for LeakSignal Proxy. Will depend on your version and deployment mechanism (nginx, envoy, WASM).
-proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
 
 # Required, API Key from the LeakSignal Command dashboard. Alternatively, the deployment name from LeakAgent.
 apiKey: MY_API_KEY
@@ -39,8 +39,8 @@ grpcMode: default
 # Optional. If `true` (default), then L4 streams are also scanned by LeakSignal Proxy.
 enableStreaming: true
 
-# Optional. If `true` (not default), istio-proxy containers are updated to a corresponding image with support for dynamic plugins, and the native LeakSignal Proxy module is installed.
-native: false
+# Optional. If `true` (default), istio-proxy containers are updated to a corresponding image with support for dynamic plugins, and the native LeakSignal Proxy module is installed.
+native: true
 
 # Optional. If `true` (default), if LeakSignal Proxy has a failure, then all traffic is routed around it.
 failOpen: true

--- a/docs/docs/Operator/Deployment.md
+++ b/docs/docs/Operator/Deployment.md
@@ -40,7 +40,7 @@ The easiest way to deploy the Operator without OLM is with the Helm Chart:
 
 ```
 helm upgrade --install leaksignal-operator oci://registry-1.docker.io/leaksignal/leaksignal-operator \
-  --version 1.8.1-helm \
+  --version 1.9.0-helm \
   --namespace leaksignal-operator \
   --create-namespace
 ```

--- a/docs/docs/Operator/Getting Started.md
+++ b/docs/docs/Operator/Getting Started.md
@@ -31,8 +31,8 @@ kind: LeaksignalIstio
 metadata:
   name: leaksignal-istio
 spec:
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   apiKey: MY_API_KEY
 ```
 
@@ -45,8 +45,8 @@ kind: LeaksignalIstio
 metadata:
   name: leaksignal-istio
 spec:
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   apiKey: MY_API_KEY
   upstreamLocation: ingestion.leaksignal.mydomain.com
 ```
@@ -59,8 +59,8 @@ kind: LeaksignalIstio
 metadata:
   name: leaksignal-istio
 spec:
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   apiKey: MY_API_KEY
   upstreamLocation: ingestion.leaksignal.mydomain.com
   caBundle: /etc/ssl/certs/ca-bundle.crt
@@ -75,8 +75,8 @@ kind: LeaksignalIstio
 metadata:
   name: leaksignal-istio
 spec:
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   apiKey: my_policy_name
 
   upstreamLocation: leakagent.leakagent.svc.cluster.local
@@ -93,8 +93,8 @@ kind: LeaksignalIstio
 metadata:
   name: leaksignal-istio
 spec:
-  proxyVersion: 2024_02_14_13_47_18_c5db81b_0.10.1
-  proxyHash: a3e851833223951f3460c4851d088ff1efc0a955cba7a68c7cafa0e596c474b2
+  proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
+  proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
   apiKey: my_policy_name
 
   upstreamLocation: leakagent.mydomain.com

--- a/examples/envoy/envoy_agent.yaml
+++ b/examples/envoy/envoy_agent.yaml
@@ -51,10 +51,10 @@ static_resources:
                   code:
                     remote:
                       http_uri:
-                        uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                        uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                         timeout: 10s
                         cluster: leaksignal_infra
-                      sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                      sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                       retry_policy:
                         num_retries: 10
           - name: envoy.filters.http.router

--- a/examples/envoy/envoy_command_remote_wasm.yaml
+++ b/examples/envoy/envoy_command_remote_wasm.yaml
@@ -55,11 +55,11 @@ static_resources:
                   code:
                     remote:
                       http_uri:
-                        uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                        uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                         timeout:
                           seconds: 10
                         cluster: leaksignal_infra
-                      sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                      sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                       retry_policy:
                         num_retries: 10
           - name: envoy.filters.http.router

--- a/examples/istio/leaksignal.yaml
+++ b/examples/istio/leaksignal.yaml
@@ -40,10 +40,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                  sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_agent.yaml
+++ b/examples/istio/leaksignal_agent.yaml
@@ -40,10 +40,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                    uri: http://ingestion.leakagent.svc.cluster.local:8121/proxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                  sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_ns.yaml
+++ b/examples/istio/leaksignal_ns.yaml
@@ -39,10 +39,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                  sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/examples/istio/leaksignal_service.yaml
+++ b/examples/istio/leaksignal_service.yaml
@@ -25,10 +25,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                    uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                  sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER
@@ -82,10 +82,10 @@ spec:
                 code:
                   remote:
                     http_uri:
-                      uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                      uri: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                       timeout: 10s
                       cluster: leaksignal_infra
-                    sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                    sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                     retry_policy:
                       num_retries: 10
   - applyTo: CLUSTER

--- a/examples/leakagent/helm_deployment_proxy.yaml
+++ b/examples/leakagent/helm_deployment_proxy.yaml
@@ -39,10 +39,10 @@ spec:
               code:
                 remote:
                   http_uri:
-                    uri: http://leakagent.leakagent.svc.cluster.local:8121/proxy/2024_09_24_18_05_40_d6b5a2c_0.12.0/leaksignal.wasm
+                    uri: http://leakagent.leakagent.svc.cluster.local:8121/proxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
                     timeout: 10s
                     cluster: leaksignal_infra
-                  sha256: d82bbffdd8c3e568cf0a4669406b0cbc81a65efa3d813634222ca3878657f8a3
+                  sha256: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
                   retry_policy:
                     num_retries: 10
   - applyTo: HTTP_FILTER

--- a/leakagent_helm/Chart.yaml
+++ b/leakagent_helm/Chart.yaml
@@ -4,6 +4,6 @@ description: A helm chart to install LeakAgent
 
 type: application
 
-version: 0.12.0-helm
+version: 0.12.1-helm
 
-appVersion: "0.12.0"
+appVersion: "0.12.1"


### PR DESCRIPTION
Changes:
* Websocket protocol support
* TLS interception improvements including OCSP/CRL support
* Ratelimit blocked rule tracking in response headers

Direct S3 WASM Download: https://leakproxy.s3.us-west-2.amazonaws.com/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
Direct S3 x86-64 Download: https://leakproxy.s3.us-west-2.amazonaws.com/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.so
Ingestion-S3 WASM Proxy Download: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.wasm
Ingestion-S3 x86-64 Proxy Download: https://ingestion.app.leaksignal.com/s3/leakproxy/2024_12_17_18_05_29_ad72a34_0.12.1/leaksignal.so
Full Version: 2024_12_17_18_05_29_ad72a34_0.12.1
SHA256 of leaksignal.wasm: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
SHA256 of leaksignal.so (x86-64): bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
Operator configuration snippet for WASM:
```
proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
proxyHash: 3ef483943396a8c8f4818bd119ce5993ef258604d028bc983710da3624465d54
native: false
```
Operator configuration snippet for x86-64:
```
proxyVersion: 2024_12_17_18_05_29_ad72a34_0.12.1
proxyHash: bc596a6af6de7e65e52c0fb6039ae44220108ba75db5f7159ed8353e6ec05a39
```
